### PR TITLE
fixup: silent deadlines

### DIFF
--- a/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserverTest.java
+++ b/providers/flagd/src/test/java/dev/openfeature/contrib/providers/flagd/resolver/grpc/EventStreamObserverTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +25,8 @@ import com.google.protobuf.Value;
 
 import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.Cache;
 import dev.openfeature.flagd.grpc.evaluation.Evaluation.EventStreamResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 
 class EventStreamObserverTest {
 
@@ -81,6 +84,15 @@ class EventStreamObserverTest {
             // we notify the error
             assertEquals(1, states.size());
             assertFalse(states.get(0));
+        }
+
+        @Test
+        public void deadlineExceeded() {
+            stream.onError(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
+            // we flush the cache
+            verify(cache, never()).clear();
+            // we notify the error
+            assertEquals(0, states.size());
         }
 
         @Test


### PR DESCRIPTION
Based on the advice of a gRPC maintainer and my local experimentation, we cannot expect that the deadline being reached in streams will gracefully end the stream. We only saw that due to a funny race condition in grpc-go (see: https://github.com/grpc/grpc-java/issues/11580#issuecomment-2392003580).

This change silently handles DEADLINE_EXCEEDED by:

- only logging debug message
- NOT emitting anything to the connection lambda/queue

This means that when our deadline is exceeded, the provider does NOT go into an error state, or log a message - it just silently re-establishes the stream - if the stream fails subsequently, all the normal error handling is fired.

I tested this manually and it works as expected, and also added some unit tests.